### PR TITLE
chore(release): v0.9.29 [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,7 @@
-## 0.9.28 (2024-11-12)
+## 0.9.29 (2024-11-12)
+
+
+### Bug Fixes
+
+* immediatelyRender as false to avoid hydration mismatch ([#83](https://github.com/tiavina-mika/mui-tiptap-editor/issues/83)) ([6d0e27b](https://github.com/tiavina-mika/mui-tiptap-editor/commit/6d0e27b83183c70a0406dc2b1a709c47337a2b45))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-tiptap-editor",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "description": "Easy to use Tiptap WYSIWYG rich text editor using Material UI (MUI) for React",
   "keywords": [
     "mui",


### PR DESCRIPTION
### Bug Fixes

* immediatelyRender as false to avoid hydration mismatch ([#83](https://github.com/tiavina-mika/mui-tiptap-editor/issues/83)) ([6d0e27b](https://github.com/tiavina-mika/mui-tiptap-editor/commit/6d0e27b83183c70a0406dc2b1a709c47337a2b45))