### PR TITLE
fix: set NODE_AUTH_TOKEN alongside NPM_TOKEN in release job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,6 +66,9 @@ jobs:
           path: dist/
       # Wraps semantic-release and exposes `new_release_published` so downstream jobs
       # (Storybook/Pages, e2e, demo, badges) can be skipped when nothing was actually published.
+      # NODE_AUTH_TOKEN must be set here too: the Setup Node.js step's registry-url wrote a
+      # .npmrc referencing ${NODE_AUTH_TOKEN}, which resolves to empty without it, shadowing
+      # the token @semantic-release/npm sets up itself from NPM_TOKEN and silently breaking auth.
       - name: Publish package on NPM 📦
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
@@ -76,6 +79,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   deploy-storybook:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `Setup Node.js` in the `release` job sets `registry-url`, which makes the action write a `.npmrc` referencing `${NODE_AUTH_TOKEN}`
- That variable was never set in the job, so it resolved to empty and shadowed the token `@semantic-release/npm` configures itself from `NPM_TOKEN`
- This caused `npm publish`/`npm whoami` to silently fail auth, surfacing as `EINVALIDNPMTOKEN` in semantic-release even with a valid, freshly-rotated npm token (confirmed working locally via `npm whoami` / `npm publish --dry-run`, and the npm token dashboard showed "Last used: never" despite the job running)
- Fix: also set `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` on the publish step so the generated `.npmrc` resolves to a valid token

## Test plan
- [ ] Merge and confirm the `release` job's "Publish package on NPM" step succeeds
- [ ] Confirm the npm token's "Last used" timestamp updates after the run
- [ ] Confirm a new version is published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)