### PR TITLE
fix: use GH_TOKEN for checkout in release job so semantic-release can push to protected main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,10 +38,15 @@ jobs:
     outputs:
       published: ${{ steps.semantic.outputs.new_release_published }}
     steps:
+      # token must be GH_TOKEN (not the default GITHUB_TOKEN) so the git credentials persisted
+      # here are the admin PAT that main's branch protection allows to bypass — the actual
+      # `git push` issued later by @semantic-release/git reuses whatever checkout persisted here,
+      # regardless of the GITHUB_TOKEN env passed to the semantic-release step itself.
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- `actions/checkout` in the `release` job defaulted to the automatic `GITHUB_TOKEN`, so the git credentials it persisted belonged to `github-actions[bot]` (no branch protection bypass) instead of the admin PAT (`GH_TOKEN`) already wired into the semantic-release step's `env`
- This caused `GH006: Protected branch update failed for refs/heads/main` on the version-bump push, even though semantic-release's own preflight check ("Allowed to push to the Git repository") reported success using `GH_TOKEN` via the API
- Fix: pass `token: ${{ secrets.GH_TOKEN }}` to the `Checkout code` step so the persisted git credentials match the admin PAT that `main`'s branch protection (`enforce_admins: false`) allows to bypass

See `docs/GITHUB_BRANCH_PROTECTION_SETUP.md` for the full writeup of this failure mode.

## Test plan
- [ ] Merge and confirm the next `ci-cd.yml` run on `main` completes the `release` job without GH006
- [ ] Confirm the pending release (currently blocked, next version `3.0.0`) publishes to npm and creates the GitHub release/tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)